### PR TITLE
Fixed a compile time error

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -308,7 +308,7 @@ func (s *Shell) Register(command string, function CmdFunc) {
 	// readline library does not provide a better way
 	// yet than to regenerate the AutoComplete
 	// TODO modify when available
-	var pcItems []*readline.PrefixCompleter
+	var pcItems []readline.PrefixCompleterInterface
 	for word, _ := range s.functions {
 		pcItems = append(pcItems, readline.PcItem(word))
 	}


### PR DESCRIPTION
I had the following compile time error on my machine using Go 1.5.1 on Ubuntu 15.10. I do not know if it's a common issue, but I fixed the problem. 

The example and my personal project is now running flawlessly.

> go run ishell/example/main.go

/home/mlavaert/gocode/src/github.com/abiosoft/ishell/ishell.go:321: cannot use pcItems (type []*readline.PrefixCompleter) as type []readline.PrefixCompleterInterface in argument to readline.NewPrefixCompleter