### PR TITLE
Bugfixes for ishell

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -191,7 +191,7 @@ func (s *Shell) ReadLine() string {
 func (s *Shell) readLine() (line string, err error) {
 	consumer := make(chan lineString)
 	defer close(consumer)
-	s.reader.readLine(consumer)
+	go s.reader.readLine(consumer)
 	ls := <-consumer
 	return ls.line, ls.err
 }

--- a/ishell.go
+++ b/ishell.go
@@ -190,6 +190,7 @@ func (s *Shell) ReadLine() string {
 
 func (s *Shell) readLine() (line string, err error) {
 	consumer := make(chan lineString)
+	defer close(consumer)
 	s.reader.readLine(consumer)
 	ls := <-consumer
 	return ls.line, ls.err

--- a/reader.go
+++ b/reader.go
@@ -63,30 +63,26 @@ func (s *shellReader) readLine(consumer chan lineString) {
 	}
 	s.reading = true
 	// start reading
-	go func() {
-		// detect if print is called to
-		// prevent readline lib from clearing line.
-		// TODO find better way.
-		shellPrompt := s.prompt
-		prompt := s.rlPrompt()
-		if s.buf.Len() > 0 {
-			prompt += s.buf.String()
-			s.buf.Truncate(0)
-		}
 
-		// use printed statement as prompt
-		s.scanner.SetPrompt(prompt)
+	// detect if print is called to
+	// prevent readline lib from clearing line.
+	// TODO find better way.
+	shellPrompt := s.prompt
+	prompt := s.rlPrompt()
+	if s.buf.Len() > 0 {
+		prompt += s.buf.String()
+		s.buf.Truncate(0)
+	}
 
-		line, err := s.scanner.Readline()
+	// use printed statement as prompt
+	s.scanner.SetPrompt(prompt)
 
-		// reset prompt
-		s.scanner.SetPrompt(shellPrompt)
+	line, err := s.scanner.Readline()
 
-		ls := lineString{string(line), err}
-		s.Lock()
-		defer s.Unlock()
-		consumer <- ls
-		s.reading = false
-	}()
+	// reset prompt
+	s.scanner.SetPrompt(shellPrompt)
 
+	ls := lineString{string(line), err}
+	consumer <- ls
+	s.reading = false
 }

--- a/reader.go
+++ b/reader.go
@@ -15,7 +15,7 @@ type (
 
 	shellReader struct {
 		scanner      *readline.Instance
-		consumers    []chan lineString
+		consumers    chan lineString
 		reading      bool
 		readingMulti bool
 		buf          *bytes.Buffer
@@ -56,7 +56,7 @@ func (s *shellReader) setMultiMode(use bool) {
 func (s *shellReader) readLine(consumer chan lineString) {
 	s.Lock()
 	defer s.Unlock()
-	s.consumers = append(s.consumers, consumer)
+
 	// already reading
 	if s.reading {
 		return
@@ -85,12 +85,7 @@ func (s *shellReader) readLine(consumer chan lineString) {
 		ls := lineString{string(line), err}
 		s.Lock()
 		defer s.Unlock()
-		for i := range s.consumers {
-			c := s.consumers[i]
-			go func(c chan lineString) {
-				c <- ls
-			}(c)
-		}
+		consumer <- ls
 		s.reading = false
 	}()
 


### PR DESCRIPTION
Hi,

I fixed some memoryleak in reader.readLine. You can reproduce it if you spawn an ishell and press enter a few times. The problem is that new channels are created for each new line, this channels never get garbage collected and aren't used further in the program. So ishell can use up gigabytes of ram easily.

Also I refactored the invokation of reader.readLine by shell.readLine via goroutine. It should be much clearer now that shell.readLine is waiting for read.readLine.

Regards,
Sven