### PR TITLE
Err funcs

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -19,6 +19,8 @@ type Actions interface {
 	// ReadPassword reads password from standard input without echoing the characters.
 	// Note that this only works as expected when the standard input is a terminal.
 	ReadPassword() string
+	// ReadPasswordErr is ReadPassword but returns error as well
+	ReadPasswordErr() (string, error)
 	// ReadMultiLinesFunc reads multiple lines from standard input. It passes each read line to
 	// f and stops reading when f returns false.
 	ReadMultiLinesFunc(f func(string) bool) string
@@ -76,6 +78,10 @@ func (s *shellActionsImpl) ReadLineErr() (string, error) {
 
 func (s *shellActionsImpl) ReadPassword() string {
 	return s.reader.readPassword()
+}
+
+func (s *shellActionsImpl) ReadPasswordErr() (string, error) {
+	return s.reader.readPasswordErr()
 }
 
 func (s *shellActionsImpl) ReadMultiLinesFunc(f func(string) bool) string {

--- a/actions.go
+++ b/actions.go
@@ -14,6 +14,8 @@ import (
 type Actions interface {
 	// ReadLine reads a line from standard input.
 	ReadLine() string
+	// ReadLineErr is ReadLine but returns error as well
+	ReadLineErr() (string, error)
 	// ReadPassword reads password from standard input without echoing the characters.
 	// Note that this only works as expected when the standard input is a terminal.
 	ReadPassword() string
@@ -66,6 +68,10 @@ type shellActionsImpl struct {
 func (s *shellActionsImpl) ReadLine() string {
 	line, _ := s.readLine()
 	return line
+}
+
+func (s *shellActionsImpl) ReadLineErr() (string, error) {
+	return s.readLine()
 }
 
 func (s *shellActionsImpl) ReadPassword() string {

--- a/reader.go
+++ b/reader.go
@@ -47,10 +47,7 @@ func (s *shellReader) readPasswordErr() (string, error) {
 		s.buf.Truncate(0)
 	}
 	password, err := s.scanner.ReadPassword(prompt)
-	if err != nil {
-		return "", err
-	}
-	return string(password), nil
+	return string(password), err
 }
 
 func (s *shellReader) readPassword() string {

--- a/reader.go
+++ b/reader.go
@@ -40,14 +40,22 @@ func (s *shellReader) rlPrompt() string {
 	return ""
 }
 
-func (s *shellReader) readPassword() string {
+func (s *shellReader) readPasswordErr() (string, error) {
 	prompt := ""
 	if s.buf.Len() > 0 {
 		prompt = s.buf.String()
 		s.buf.Truncate(0)
 	}
-	password, _ := s.scanner.ReadPassword(prompt)
-	return string(password)
+	password, err := s.scanner.ReadPassword(prompt)
+	if err != nil {
+		return "", err
+	}
+	return string(password), nil
+}
+
+func (s *shellReader) readPassword() string {
+	password, _ := s.readPasswordErr()
+	return password
 }
 
 func (s *shellReader) setMultiMode(use bool) {


### PR DESCRIPTION
I added new versions of some methods because it is the only way I know to distinguish empty input and interruption (Ctrl-C, `readline.ErrInterrupt`).