### PR TITLE
Fixed readline.ClearScreen call for windows #43

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -6,8 +6,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-
-	"github.com/chzyer/readline"
 )
 
 // Actions are actions that can be performed by a shell.
@@ -161,11 +159,6 @@ func (s *shellActionsImpl) Stop() {
 
 func (s *shellActionsImpl) HelpText() string {
 	return s.rootCmd.HelpText()
-}
-
-func clearScreen(s *Shell) error {
-	_, err := readline.ClearScreen(s.writer)
-	return err
 }
 
 func showPaged(s *Shell, text string) error {

--- a/command_test.go
+++ b/command_test.go
@@ -3,7 +3,7 @@ package ishell_test
 import (
 	"testing"
 
-	"ishell"
+	"github.com/abiosoft/ishell"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/command_test.go
+++ b/command_test.go
@@ -3,7 +3,7 @@ package ishell_test
 import (
 	"testing"
 
-	"github.com/abiosoft/ishell"
+	"ishell"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,0 +1,12 @@
+// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
+
+package ishell
+
+import (
+	"github.com/chzyer/readline"
+)
+
+func clearScreen(s *Shell) error {
+	_, err := readline.ClearScreen(s.writer)
+	return err
+}

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package ishell
+
+import (
+	"github.com/chzyer/readline"
+)
+
+func clearScreen(s *Shell) error {
+	return readline.ClearScreen(s.writer)
+}


### PR DESCRIPTION
This fix mimics how readline has the ClearScreen function organized into two separate utils_*.go files. I've simply moved the clearScreen function into two different util files which are conditionally built on the same platforms as the readline utils_*.go files.

I'm not sure if this is the cleanest solution but it works and passes tests. It might make sense for readline to change it to provide the same interface, but this will do in the meantime.