### PR TITLE
Fixed configured prompt not being set

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -70,7 +70,7 @@ func NewWithConfig(conf *readline.Config) *Shell {
 		rootCmd: &Cmd{},
 		reader: &shellReader{
 			scanner:     rl,
-			prompt:      defaultPrompt,
+			prompt:      rl.Config.Prompt,
 			multiPrompt: defaultMultiPrompt,
 			showPrompt:  true,
 			buf:         &bytes.Buffer{},


### PR DESCRIPTION
Previously `defaultPrompt` always overwrote the user-configured prompt.

There's still no way to set the multiline-prompt, as this would require deeper changes. I suggest using a separate config struct for ishell which wraps the readline settings. This would break the API, though.
