### PR TITLE
Added support for command aliases

### DIFF
--- a/command.go
+++ b/command.go
@@ -11,6 +11,8 @@ import (
 type Cmd struct {
 	// Command name.
 	Name string
+	// Command name aliases.
+	Aliases []string
 	// Function to execute for the command.
 	Func func(c *Context)
 	// One liner help message for the command.
@@ -91,12 +93,31 @@ func (c Cmd) HelpText() string {
 	return b.String()
 }
 
+// findChildCmd returns the subcommand with matching name or alias.
+func (c *Cmd) findChildCmd(name string) *Cmd {
+	// find perfect matches first
+	if cmd, ok := c.children[name]; ok {
+		return cmd
+	}
+
+	// find alias matching the name
+	for _, cmd := range c.children {
+		for _, alias := range cmd.Aliases {
+			if alias == name {
+				return cmd
+			}
+		}
+	}
+
+	return nil
+}
+
 // FindCmd finds the matching Cmd for args.
 // It returns the Cmd and the remaining args.
 func (c Cmd) FindCmd(args []string) (*Cmd, []string) {
 	var cmd *Cmd
 	for i, arg := range args {
-		if cmd1, ok := c.children[arg]; ok {
+		if cmd1 := c.findChildCmd(arg); cmd1 != nil {
 			cmd = cmd1
 			c = *cmd
 			continue

--- a/command_test.go
+++ b/command_test.go
@@ -13,6 +13,7 @@ func newCmd(name string, help string) *ishell.Cmd {
 		Help: help,
 	}
 }
+
 func TestAddCommand(t *testing.T) {
 	cmd := newCmd("root", "")
 	assert.Equal(t, len(cmd.Children()), 0, "should be empty")
@@ -47,6 +48,31 @@ func TestFindCmd(t *testing.T) {
 	res, err = cmd.FindCmd([]string{"child3"})
 	if err == nil {
 		t.Error("should not find this child!")
+	}
+	assert.Nil(t, res)
+}
+
+func TestFindAlias(t *testing.T) {
+	cmd := newCmd("root", "")
+	subcmd := newCmd("child1", "")
+	subcmd.Aliases = []string{"alias1", "alias2"}
+	cmd.AddCmd(subcmd)
+
+	res, err := cmd.FindCmd([]string{"alias1"})
+	if err != nil {
+		t.Fatal("finding alias should work")
+	}
+	assert.Equal(t, res.Name, "child1")
+
+	res, err = cmd.FindCmd([]string{"alias2"})
+	if err != nil {
+		t.Fatal("finding alias should work")
+	}
+	assert.Equal(t, res.Name, "child1")
+
+	res, err = cmd.FindCmd([]string{"alias3"})
+	if err == nil {
+		t.Fatal("should not find this child!")
 	}
 	assert.Nil(t, res)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -40,8 +40,9 @@ func main() {
 
 	// handle "greet".
 	shell.AddCmd(&ishell.Cmd{
-		Name: "greet",
-		Help: "greet user",
+		Name:    "greet",
+		Aliases: []string{"hello", "welcome"},
+		Help:    "greet user",
 		Func: func(c *ishell.Context) {
 			name := "Stranger"
 			if len(c.Args) > 0 {


### PR DESCRIPTION
Happy to update the README, too, if this gets accepted.

Note: the performance of this change could be slightly improved, but would require breaking the existing API. I don't expect anyone to use ishell with many thousands sub-commands though, so I preferred keeping a stable API.