### PR TITLE
Allow custom pager to be specified

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -163,11 +163,16 @@ func (s *shellActionsImpl) HelpText() string {
 
 func showPaged(s *Shell, text string) error {
 	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command("more")
-	} else {
-		cmd = exec.Command("less")
+
+	if s.pager == "" {
+		if runtime.GOOS == "windows" {
+			s.pager = "more"
+		} else {
+			s.pager = "less"
+		}
 	}
+
+	cmd = exec.Command(s.pager, s.pagerArgs...)
 	cmd.Stdout = s.writer
 	cmd.Stderr = s.writer
 	cmd.Stdin = bytes.NewBufferString(text)

--- a/ishell.go
+++ b/ishell.go
@@ -50,6 +50,8 @@ type Shell struct {
 	autoHelp          bool
 	rawArgs           []string
 	progressBar       ProgressBar
+	pager             string
+	pagerArgs         []string
 	contextValues
 	Actions
 }
@@ -408,6 +410,12 @@ func (s *Shell) SetHomeHistoryPath(path string) {
 // SetOut sets the writer to write outputs to.
 func (s *Shell) SetOut(writer io.Writer) {
 	s.writer = writer
+}
+
+// SetPager sets the pager and its arguments for paged output
+func (s *Shell) SetPager(pager string, args []string) {
+	s.pager = pager
+	s.pagerArgs = args
 }
 
 func initSelected(init []int, max int) []int {


### PR DESCRIPTION
It's useful if ishell allows a custom pager (and arguments) to be specified. My use case is I need to use `less -R` to support coloured output via the pager.