### PR TITLE
Replace go-shlex with fork that supports \t

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ MIT
 ## Credits
 Library | Use
 ------- | -----
-[github.com/flynn-archive/go-shlex](https://github.com/flynn-archive/go-shlex) | splitting input into command and args.
+[github.com/GetStream/go-shlex](https://github.com/GetStream/go-shlex) | splitting input into command and args.
 [github.com/chzyer/readline](https://github.com/chzyer/readline) | readline capabilities.
 
 

--- a/completer.go
+++ b/completer.go
@@ -3,7 +3,7 @@ package ishell
 import (
 	"strings"
 
-	"github.com/flynn-archive/go-shlex"
+	"github.com/GetStream/go-shlex"
 )
 
 type iCompleter struct {

--- a/ishell.go
+++ b/ishell.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
-	"github.com/flynn-archive/go-shlex"
+	"github.com/GetStream/go-shlex"
 )
 
 const (


### PR DESCRIPTION
This fixes #71 

For details of the changes in the fork, check out this diff:
https://github.com/GetStream/go-shlex/compare/3f9db97f856818214da2e1057f8ad84803971cff...HEAD