### PR TITLE
fix panic on completer by checking for pos len

### DIFF
--- a/completer.go
+++ b/completer.go
@@ -25,7 +25,7 @@ func (ic iCompleter) Do(line []rune, pos int) (newLine [][]rune, length int) {
 
 	var cWords []string
 	prefix := ""
-	if len(words) > 0 && line[pos-1] != ' ' {
+	if len(words) > 0 && pos > 0 && line[pos-1] != ' ' {
 		prefix = words[len(words)-1]
 		cWords = ic.getWords(words[:len(words)-1])
 	} else {


### PR DESCRIPTION
fixes panic on completer when cursor is at beginning of word.

if pos is 0 then `line[pos-1]` evaluates to an index which is negative and does not exist.