### PR TITLE
Custom Checklist and MultiChoice strings

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -48,6 +48,11 @@ type Actions interface {
 	// SetMultiPrompt sets the prompt string used for multiple lines. The string to be displayed before
 	// the cursor; starting from the second line of input.
 	SetMultiPrompt(prompt string)
+	// SetMultiChoicePrompt sets the prompt strings used for MultiChoice().
+	SetMultiChoicePrompt(prompt, spacer string)
+	// SetChecklistOptions sets the strings representing the options of Checklist().
+	// The generated string depends on SetMultiChoicePrompt() also.
+	SetChecklistOptions(open, selected string)
 	// ShowPrompt sets whether prompt should show when requesting input for ReadLine and ReadPassword.
 	// Defaults to true.
 	ShowPrompt(show bool)
@@ -130,6 +135,15 @@ func (s *shellActionsImpl) SetPrompt(prompt string) {
 
 func (s *shellActionsImpl) SetMultiPrompt(prompt string) {
 	s.reader.multiPrompt = prompt
+}
+
+func (s *shellActionsImpl) SetMultiChoicePrompt(prompt, spacer string) {
+	strMultiChoice = prompt
+	strMultiChoiceSpacer = spacer
+}
+func (s *shellActionsImpl) SetChecklistOptions(open, selected string) {
+	strMultiChoiceOpen = open
+	strMultiChoiceSelect = selected
 }
 
 func (s *shellActionsImpl) ShowPrompt(show bool) {

--- a/example/main.go
+++ b/example/main.go
@@ -17,6 +17,10 @@ func main() {
 	// display info.
 	shell.Println("Sample Interactive Shell")
 
+	//Consider the unicode characters supported by the users font
+	//shell.SetMultiChoicePrompt(" >>"," - ")
+	//shell.SetChecklistOptions("[ ] ","[X] ")
+
 	// handle login.
 	shell.AddCmd(&ishell.Cmd{
 		Name: "login",

--- a/ishell.go
+++ b/ishell.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/abiosoft/readline"
 	"github.com/fatih/color"
@@ -29,6 +30,11 @@ const (
 var (
 	errNoHandler          = errors.New("incorrect input, try 'help'")
 	errNoInterruptHandler = errors.New("no interrupt handler")
+	strMultiChoice        = " ❯"
+	strMultiChoiceWin     = " >"
+	strMultiChoiceSpacer  = " "
+	strMultiChoiceOpen    = "⬡ "
+	strMultiChoiceSelect  = "⬢ "
 )
 
 // Shell is an interactive cli shell.
@@ -583,25 +589,25 @@ func (s *Shell) multiChoice(options []string, text string, init []int, multiResu
 
 func buildOptionsStrings(options []string, selected []int, index int) []string {
 	var strs []string
-	symbol := " ❯"
+	symbol := strMultiChoice
 	if runtime.GOOS == "windows" {
-		symbol = " >"
+		symbol = strMultiChoiceWin
 	}
 	for i, opt := range options {
-		mark := "⬡ "
+		mark := strMultiChoiceOpen
 		if selected == nil {
-			mark = " "
+			mark = strMultiChoiceSpacer
 		}
 		for _, s := range selected {
 			if s == i {
-				mark = "⬢ "
+				mark = strMultiChoiceSelect
 			}
 		}
 		if i == index {
 			cyan := color.New(color.FgCyan).Add(color.Bold).SprintFunc()
 			strs = append(strs, cyan(symbol+mark+opt))
 		} else {
-			strs = append(strs, "  "+mark+opt)
+			strs = append(strs, strings.Repeat(" ", utf8.RuneCountInString(symbol))+mark+opt)
 		}
 	}
 	return strs


### PR DESCRIPTION
Strings used in ishell's buildOptionsString(...) can be edited similar to SetPrompt()
New Actions:
SetMultiChoicePrompt(prompt,spacer)
SetChecklistOptions(open,checked)

Strings are stored as global vars in ishell
Length of MultiChoicePrompt will be replaced properly by spaces when cursor moves

Motivation:
I love this shell and use it for some programs now, but i noticed that some terminals (e.g. xterm) doesn't show the right runes. This has nothing to do with not supporting unicode though and rather depends on the font used.
By making the strings used variables the user has total control over these runes and may even set them during runtime.

Would Close  Issue #61 