### PR TITLE
Create a accessor to shell's multiChoiceActive attribute

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -104,6 +104,16 @@ func (s *Shell) Wait() {
 	<-s.haltChan
 }
 
+// GetRootCmd returns the shell's root command.
+func (s *Shell) GetRootCmd() *Cmd {
+	return s.rootCmd
+}
+
+// SetRootCmd sets the shell's root command.
+func (s *Shell) SetRootCmd(cmd *Cmd) {
+	s.rootCmd = cmd
+}
+
 func (s *Shell) stop() {
 	if !s.Active() {
 		return

--- a/ishell.go
+++ b/ishell.go
@@ -104,6 +104,11 @@ func (s *Shell) Wait() {
 	<-s.haltChan
 }
 
+// MultiChoiceActive returns true if the shell is in the multi choice selection mode
+func (s *Shell) MultiChoiceActive() bool {
+	return s.multiChoiceActive
+}
+
 // RootCmd returns the shell's root command.
 func (s *Shell) RootCmd() *Cmd {
 	return s.rootCmd


### PR DESCRIPTION
Creating an accessor to the shell's multiChoiceActive attribute allows the developer of a custom completer to know whether the shell is in MultiChoice mode or not, thus disabling the completer if needed.

Example:
Someone writing a custom completer can not disable it when MultiChoice is called as Shell.multiChoiceActive is private, you're using this attribute in your completer's disabled function to know when not to do the completion.

```
func (ic iCompleter) Do(line []rune, pos int) (newLine [][]rune, length int) {
	if ic.disabled != nil && ic.disabled() {
		return nil, len(line)
	}
ic.disabled being defined here:

func (s *Shell) initCompleters() {
	s.setCompleter(iCompleter{cmd: s.rootCmd, disabled: func() bool { return s.multiChoiceActive }})
}
```

One possible solution would be to create a accessor for Shell.multiChoiceActive.