### PR TITLE
Add NewWithReadline to have a shell with custom readline Instance

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -74,23 +74,8 @@ func NewWithConfig(conf *readline.Config) *Shell {
 		log.Println("Shell or operating system not supported.")
 		log.Fatal(err)
 	}
-	shell := &Shell{
-		rootCmd: &Cmd{},
-		reader: &shellReader{
-			scanner:     rl,
-			prompt:      rl.Config.Prompt,
-			multiPrompt: defaultMultiPrompt,
-			showPrompt:  true,
-			buf:         &bytes.Buffer{},
-			completer:   readline.NewPrefixCompleter(),
-		},
-		writer:   conf.Stdout,
-		autoHelp: true,
-	}
-	shell.Actions = &shellActionsImpl{Shell: shell}
-	shell.progressBar = newProgressBar(shell)
-	addDefaultFuncs(shell)
-	return shell
+
+	return NewWithReadline(rl)
 }
 
 // NewWithReadline creates a new shell with a custom readline instance.

--- a/ishell.go
+++ b/ishell.go
@@ -93,7 +93,7 @@ func NewWithConfig(conf *readline.Config) *Shell {
 	return shell
 }
 
-// NewWithReadline creates a new shell with custom readline instance.
+// NewWithReadline creates a new shell with a custom readline instance.
 func NewWithReadline(rl *readline.Instance) *Shell {
 	shell := &Shell{
 		rootCmd: &Cmd{},
@@ -105,7 +105,7 @@ func NewWithReadline(rl *readline.Instance) *Shell {
 			buf:         &bytes.Buffer{},
 			completer:   readline.NewPrefixCompleter(),
 		},
-		writer:   conf.Stdout,
+		writer:   rl.Config.Stdout,
 		autoHelp: true,
 	}
 	shell.Actions = &shellActionsImpl{Shell: shell}

--- a/ishell.go
+++ b/ishell.go
@@ -93,6 +93,27 @@ func NewWithConfig(conf *readline.Config) *Shell {
 	return shell
 }
 
+// NewWithReadline creates a new shell with custom readline instance.
+func NewWithReadline(rl *readline.Instance) *Shell {
+	shell := &Shell{
+		rootCmd: &Cmd{},
+		reader: &shellReader{
+			scanner:     rl,
+			prompt:      rl.Config.Prompt,
+			multiPrompt: defaultMultiPrompt,
+			showPrompt:  true,
+			buf:         &bytes.Buffer{},
+			completer:   readline.NewPrefixCompleter(),
+		},
+		writer:   conf.Stdout,
+		autoHelp: true,
+	}
+	shell.Actions = &shellActionsImpl{Shell: shell}
+	shell.progressBar = newProgressBar(shell)
+	addDefaultFuncs(shell)
+	return shell
+}
+
 // Start starts the shell but does not wait for it to stop.
 func (s *Shell) Start() {
 	s.prepareRun()


### PR DESCRIPTION
This PR creates a new helper function NewWithReadline in ishell.go to allow users to create a shell instance with a custom readline instance. 
Plus we use this function in NewWithConfig to refactor code.

I needed that in a project to call some member methods of the readline instance.


I've been using ishell for a few weeks now, nice and clean project, thanks!