### PR TITLE
Use os.UserHomeDir instead of os.Getenv

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -427,7 +428,23 @@ func (s *Shell) SetHistoryPath(path string) {
 // SetHomeHistoryPath is a convenience method that sets the history path
 // in user's home directory.
 func (s *Shell) SetHomeHistoryPath(path string) {
-	home, _ := os.UserHomeDir()
+	var home string
+
+	/*
+		Try to get the home directory with user.Current
+		If error occurs, use environment variables
+	*/
+	user, err := user.Current()
+	if err == nil {
+		home = user.HomeDir
+	} else {
+		if runtime.GOOS == "windows" {
+			home = os.Getenv("USERPROFILE")
+		} else {
+			home = os.Getenv("HOME")
+		}
+	}
+
 	abspath := filepath.Join(home, path)
 	s.SetHistoryPath(abspath)
 }

--- a/ishell.go
+++ b/ishell.go
@@ -427,10 +427,7 @@ func (s *Shell) SetHistoryPath(path string) {
 // SetHomeHistoryPath is a convenience method that sets the history path
 // in user's home directory.
 func (s *Shell) SetHomeHistoryPath(path string) {
-	home := os.Getenv("HOME")
-	if runtime.GOOS == "windows" {
-		home = os.Getenv("USERPROFILE")
-	}
+	home, _ := os.UserHomeDir()
 	abspath := filepath.Join(home, path)
 	s.SetHistoryPath(abspath)
 }

--- a/ishell.go
+++ b/ishell.go
@@ -430,10 +430,8 @@ func (s *Shell) SetHistoryPath(path string) {
 func (s *Shell) SetHomeHistoryPath(path string) {
 	var home string
 
-	/*
-		Try to get the home directory with user.Current
-		If error occurs, use environment variables
-	*/
+	// Try to get the home directory with user.Current.
+	// If error occurs, use environment variables
 	user, err := user.Current()
 	if err == nil {
 		home = user.HomeDir


### PR DESCRIPTION
This way, SetHomeHistoryPath function works for all operating systems.