### PR TITLE
Use environment variables for home directory

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -430,17 +429,10 @@ func (s *Shell) SetHistoryPath(path string) {
 func (s *Shell) SetHomeHistoryPath(path string) {
 	var home string
 
-	// Try to get the home directory with user.Current.
-	// If error occurs, use environment variables
-	user, err := user.Current()
-	if err == nil {
-		home = user.HomeDir
+	if runtime.GOOS == "windows" {
+		home = os.Getenv("USERPROFILE")
 	} else {
-		if runtime.GOOS == "windows" {
-			home = os.Getenv("USERPROFILE")
-		} else {
-			home = os.Getenv("HOME")
-		}
+		home = os.Getenv("HOME")
 	}
 
 	abspath := filepath.Join(home, path)

--- a/ishell.go
+++ b/ishell.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -427,7 +428,23 @@ func (s *Shell) SetHistoryPath(path string) {
 // SetHomeHistoryPath is a convenience method that sets the history path
 // in user's home directory.
 func (s *Shell) SetHomeHistoryPath(path string) {
-	home, _ := os.UserHomeDir()
+	var home string
+
+	/*
+		Try to get the home directory with user.Current
+		If error occurs, use environment variables
+	*/
+	user, err := user.Current()
+	if err == nil {
+		home = user.HomeDir
+	} else {
+		if runtime.GOOS == "windows" {
+			home = os.Getenv("USERPROFILE")
+		} else {
+			home = os.Getenv("HOME")
+		}
+	}
+
 	abspath := filepath.Join(home, path)
 	s.SetHistoryPath(abspath)
 }

--- a/ishell.go
+++ b/ishell.go
@@ -427,10 +427,7 @@ func (s *Shell) SetHistoryPath(path string) {
 // SetHomeHistoryPath is a convenience method that sets the history path
 // in user's home directory.
 func (s *Shell) SetHomeHistoryPath(path string) {
-	home := os.Getenv("HOME")
-	if runtime.GOOS == "windows" {
-		home = os.Getenv("USERPROFILE")
-	}
+	home, _ := os.UserHomeDir()
 	abspath := filepath.Join(home, path)
 	s.SetHistoryPath(abspath)
 }

--- a/ishell.go
+++ b/ishell.go
@@ -430,10 +430,8 @@ func (s *Shell) SetHistoryPath(path string) {
 func (s *Shell) SetHomeHistoryPath(path string) {
 	var home string
 
-	/*
-		Try to get the home directory with user.Current
-		If error occurs, use environment variables
-	*/
+	// Try to get the home directory with user.Current.
+	// If error occurs, use environment variables
 	user, err := user.Current()
 	if err == nil {
 		home = user.HomeDir


### PR DESCRIPTION
I want to revert my commit, because the new method of getting the user home directory doesn't work with `sudo -E`

For example, let's assume that I am "foo" user, and I wrote a program using ishell (let's name the program as "bar"), and I run the command: `sudo -E ./bar`

It retrieves root's home directory path, not foo's. Because user.Current uses `/etc/passwd` instead of environment variables. I think we should use environment variables to retrieve the user home directory path.