### PR TITLE
ClearScreen function corrected

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -169,7 +169,6 @@ func main() {
 			Help: "try auto complete",
 			LongHelp: `Try dynamic autocomplete by adding and removing words.
 Then view the autocomplete by tabbing after "words" subcommand.
-
 This is an example of a long help.`,
 		}
 		autoCmd.AddCmd(&ishell.Cmd{
@@ -210,7 +209,6 @@ This is an example of a long help.`,
 			lines := ""
 			line := `%d. This is a paged text input.
 This is another line of it.
-
 `
 			for i := 0; i < 100; i++ {
 				lines += fmt.Sprintf(line, i+1)

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,12 +1,9 @@
+//go:build darwin || dragonfly || freebsd || (linux && !appengine) || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux,!appengine netbsd openbsd solaris
 
 package ishell
 
-import (
-	"github.com/abiosoft/readline"
-)
-
 func clearScreen(s *Shell) error {
-	_, err := readline.ClearScreen(s.writer)
+	_, err := s.writer.Write([]byte("\033[H\033[2J"))
 	return err
 }


### PR DESCRIPTION
I noticed that we when performed ClearScreen operation on the ishell, sometimes old values from the previous screen were still displayed. This was because in the package github.com/abiosoft/readline, `writer.Write([]byte("\033[H"))` was used to clear the screen. However, we can simply do `writer.Write([]byte("\033[H\033[2J"))` to deal with this. It successfully clears the whole screen. 

I also eliminated the need for external reference to readline package. We can use the io.Writer object of ishell directly to clear the screen.

I am attaching a screenshot for reference. The "ed ?" at the end of the first line should not be there in case of clearScreen as this was pasted from the previous screen.

#130 

![Screenshot from 2021-09-08 00-00-44](https://user-images.githubusercontent.com/43992469/132394948-aecef663-576b-4086-8f21-d49977d2d343.png)

