### PR TITLE
Fix: make ishell context values safe to use concurrently

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -669,10 +669,10 @@ func newContext(s *Shell, cmd *Cmd, args []string) *Context {
 		Args:        args,
 		RawArgs:     s.rawArgs,
 		Cmd:         *cmd,
-		contextValues: func() contextValues {
-			values := contextValues{}
-			for k := range s.contextValues {
-				values[k] = s.contextValues[k]
+		contextValues: func() *contextValues {
+			values := &contextValues{}
+			for k := range s.contextValues.vals {
+				values.Set(k, s.contextValues.vals[k])
 			}
 			return values
 		}(),


### PR DESCRIPTION
Maps are not safe to access concurrently, here we add a mutex to avoid concurrent read/write panics in ishell context values.